### PR TITLE
Fix RSpec formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,6 @@ require 'rspec/core/rake_task'
 require 'bundler/gem_tasks'
 
 # Default directory to look within is `/specs`
-# Run with `rake spec`
-RSpec::Core::RakeTask.new(:spec) do |task|
-  task.rspec_opts = ['--color', '--format', 'nested']
-end
+RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,9 @@ Coveralls.wear!
 require 'pry'
 require 'sinderella'
 
+RSpec.configure do |config|
+  config.color = true
+  config.tty = true
+  config.formatter = :documentation
+end
+


### PR DESCRIPTION
Formatting spec output for RSpec 3.2 needed some changes.
- 'documentation' instead of 'nested'
- Set RSpec configuration instead of rspec_opts which couldn't pass --color attribute
